### PR TITLE
Remove 1 level of heading depth

### DIFF
--- a/src/Category/Renderer/MarkdownRenderer.php
+++ b/src/Category/Renderer/MarkdownRenderer.php
@@ -7,6 +7,7 @@ namespace LukasRyder\Notes\Category\Renderer;
 use Generator;
 use LukasRyder\Notes\Category\Category;
 use LukasRyder\Notes\Category\NodeInterface;
+use LukasRyder\Notes\Category\ParentNodeInterface;
 use LukasRyder\Notes\Note;
 
 final class MarkdownRenderer implements RendererInterface
@@ -15,28 +16,44 @@ final class MarkdownRenderer implements RendererInterface
     private const DEFAULT_PADDING_SIZE = 2;
     private const DEFAULT_LIST_ITEM_PREFIX = '- ';
     private const DEFAULT_ENCODE_SPACES = false;
+    private const DEFAULT_HEADING_PREFIX = '#';
 
     public function __construct(
         private readonly string $paddingCharacter = self::DEFAULT_PADDING_CHARACTER,
         private readonly int $paddingSize = self::DEFAULT_PADDING_SIZE,
         private readonly string $listItemPrefix = self::DEFAULT_LIST_ITEM_PREFIX,
-        private readonly bool $encodeSpaces = self::DEFAULT_ENCODE_SPACES
+        private readonly bool $encodeSpaces = self::DEFAULT_ENCODE_SPACES,
+        private readonly string $headingPrefix = self::DEFAULT_HEADING_PREFIX
     ) {}
 
     public function render(Category $category): string
     {
-        $document = [
-            sprintf('# %s', $category->getName())
-        ];
+        $document = [];
 
         foreach ($category as $child) {
-            array_push(
-                $document,
-                ...$this->renderChild($child, 0)
-            );
+            if ($child instanceof ParentNodeInterface) {
+                array_push($document, ...$this->renderHeading($child, 1));
+
+                foreach ($child as $grandChild) {
+                    array_push($document, ...$this->renderChild($grandChild, 0));
+                }
+
+                continue;
+            }
+
+            array_push($document, ...$this->renderChild($child, 0));
         }
 
         return implode(PHP_EOL, $document);
+    }
+
+    private function renderHeading(NodeInterface $node, int $level): Generator
+    {
+        yield sprintf(
+            '%s %s',
+            str_repeat($this->headingPrefix, $level),
+            $node->getName()
+        );
     }
 
     private function renderChild(NodeInterface $node, int $depth): Generator


### PR DESCRIPTION
The root category is left out from the tree and all first level
categories get their own heading.